### PR TITLE
Only set showTags if config set to tags only

### DIFF
--- a/Install/Upgrade_dbase/42_report_engine_schema.sql
+++ b/Install/Upgrade_dbase/42_report_engine_schema.sql
@@ -36,3 +36,4 @@ CREATE TABLE `CategoryHasReport` (
   CONSTRAINT `FK_CategoryHasReport` FOREIGN KEY (`reportcategoryid`) REFERENCES `ReportCategories` (`reportcategoryid`),
   CONSTRAINT `FK_CategoryHasReport2` FOREIGN KEY (`reporttypeid`) REFERENCES `ReportTypes` (`reporttypeid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+INSERT INTO PatchLog (patchname) VALUES ('42_report_engine_schema.sql');

--- a/Install/Upgrade_dbase/43_configure_rooms.sql
+++ b/Install/Upgrade_dbase/43_configure_rooms.sql
@@ -2,3 +2,4 @@ INSERT INTO PermissionAtoms (permatomid, permatomtag, page, notes)
 	VALUES (16, "configure_rooms", "Configure Rooms", "Also triggers \"Configuration\" menu in staff menu bar.");
 INSERT INTO Permissions (permatomid, permroleid, phaseid)
 	VALUES (16, 1, NULL);
+INSERT INTO PatchLog (patchname) VALUES ('43_configure_rooms.sql');


### PR DESCRIPTION
## Description
The tags input field is displayed conditionally based on the `$showTags` flag, which is currently set by the `TRACK_TAG_USAGE` config field. This changes the flag to only be set to true if that configuration is to use tags only, not tracks. 

I left the ability to show the input field if desired to make the smallest possible impact on the code for the sake of stability and the possibility of wanting to use tags in the future.